### PR TITLE
Change Channel.props values type from String to Object (fix #99)

### DIFF
--- a/mattermost-models/src/main/java/net/bis5/mattermost/model/Channel.java
+++ b/mattermost-models/src/main/java/net/bis5/mattermost/model/Channel.java
@@ -71,6 +71,6 @@ public class Channel {
 	/** @since Mattermost Server XXX what ver? */
 	private String schemeId;
 	/** @since Mattermost Server XXX what ver? */
-	private Map<String, String> props;
+	private Map<String, Object> props;
 
 }

--- a/mattermost4j-core/pom.xml
+++ b/mattermost4j-core/pom.xml
@@ -38,6 +38,12 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.5</version>
 		</dependency>
+		<dependency>
+			<groupId>com.vdurmont</groupId>
+			<artifactId>semver4j</artifactId>
+			<version>2.2.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
For example, `channel_mentions` property value is `map[string]interface`. So we need to change Map's value type to Object.