### PR TITLE
fix: correct /teams/members/invite api call

### DIFF
--- a/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/MattermostClient.java
+++ b/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/MattermostClient.java
@@ -1099,6 +1099,7 @@ public class MattermostClient implements AutoCloseable, AuditsApi, Authenticatio
   }
 
   @Override
+  @Deprecated
   public ApiResponse<TeamMember> addTeamMember(String hash, String dataToHash, String inviteId) {
     QueryBuilder query = new QueryBuilder();
     if (StringUtils.isNotEmpty(inviteId)) {
@@ -1108,6 +1109,19 @@ public class MattermostClient implements AutoCloseable, AuditsApi, Authenticatio
       query.set("hash", hash).set("data", dataToHash);
     }
 
+    return doApiPost(getTeamsRoute() + "/members/invite" + query.toString(), null,
+        TeamMember.class);
+  }
+
+  @Override
+  public ApiResponse<TeamMember> addTeamMemberFromInvite(String token, String inviteId) {
+    QueryBuilder query = new QueryBuilder();
+    if (StringUtils.isNotEmpty(token)) {
+      query.set("token", token);
+    }
+    if (StringUtils.isNotEmpty(inviteId)) {
+      query.set("invite_id", inviteId);
+    }
     return doApiPost(getTeamsRoute() + "/members/invite" + query.toString(), null,
         TeamMember.class);
   }

--- a/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/api/TeamApi.java
+++ b/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/api/TeamApi.java
@@ -234,8 +234,17 @@ public interface TeamApi {
    * adds user to a team and return a team member.
    * 
    * @since Mattermost 4.0
+   * @deprecated API Changed on Mattermost 4.10
    */
+  @Deprecated
   ApiResponse<TeamMember> addTeamMember(String hash, String dataToHash, String inviteId);
+
+  /**
+   * add user to team from invite.
+   * 
+   * @since Mattermost 4.10
+   */
+  ApiResponse<TeamMember> addTeamMemberFromInvite(String token, String inviteId);
 
   /**
    * adds a number of users to a team and returns the team members.

--- a/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/MattermostApiTest.java
+++ b/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/MattermostApiTest.java
@@ -1751,10 +1751,18 @@ public class MattermostApiTest {
     }
 
     @Test
-    @Disabled // API for 4.0+
     public void addUserToTeamFromInvite() {
+      th.logout().loginSystemAdmin();
+      User noTeamUser = th.createUser();
+      String inviteId = th.basicTeam().getInviteId();
 
-      assertStatus(client.addTeamMember("hash", "dataToHash", "inviteId"), Status.BAD_REQUEST);
+      th.logout().loginAs(noTeamUser);
+      ApiResponse<TeamMember> response =
+          assertNoError(client.addTeamMemberFromInvite(null, inviteId));
+
+      TeamMember teamMember = response.readEntity();
+      assertEquals(th.basicTeam().getId(), teamMember.getTeamId());
+      assertEquals(noTeamUser.getId(), teamMember.getUserId());
     }
 
     @Test


### PR DESCRIPTION
The old api (TeamsApi#addUserToTeam(String, String, String)) is deprecated.

fixes #193