### PR TITLE
Update README's incoming webhook section to match current spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ client.setAccessToken(token);
 ### Use Incoming Webhook
 ```
 // You can also use builder for create client instance.
-MattermostClient client = new MattermostClient("YOUR-MATTERMOST-URL")
+IncomingWebhookClient client = new IncomingWebhookClient("YOUR-MATTERMOST-URL")
 
 IncomingWebhookRequest payload = new IncomingWebhookRequest();
 payload.setText("Hello World!");


### PR DESCRIPTION
MattermostClient#postByIcomingWebhook was moved to IncomingWebhookClient.java but the README was never updated, leading to confusion - I had to go through issues and source to find out how to post to incoming webhooks, so I assume this would help others