### PR TITLE
Add ability to configure underlying httpClient of MM client

### DIFF
--- a/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/MattermostClient.java
+++ b/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/MattermostClient.java
@@ -3,9 +3,9 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -174,7 +174,7 @@ import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
 /**
  * Mattermost API Version4 Client default implementation.
- * 
+ *
  * @author Maruyama Takayuki
  * @since 2017/06/10
  */
@@ -186,21 +186,40 @@ public class MattermostClient implements AutoCloseable, AuditsApi, Authenticatio
   protected static final String API_URL_SUFFIX = "/api/v4";
   private final String url;
   private final String apiUrl;
-  private String authToken;
-  private AuthType authType;
   private final Level clientLogLevel;
   private final boolean ignoreUnknownProperties;
   private final Client httpClient;
+  private String authToken;
+  private AuthType authType;
 
   public static MattermostClientBuilder builder() {
     return new MattermostClientBuilder();
   }
 
+  protected Client buildClient(Consumer<ClientBuilder> httpClientConfig) {
+    ClientBuilder builder = ClientBuilder.newBuilder()
+        .register(new MattermostModelMapperProvider(ignoreUnknownProperties))
+        .register(JacksonFeature.class).register(MultiPartFeature.class)
+        // needs for PUT request with null entity
+        // (/commands/{command_id}/regen_token)
+        .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true);
+    if (clientLogLevel != null) {
+      builder.register(new LoggingFeature(Logger.getLogger(getClass().getName()), clientLogLevel,
+          Verbosity.PAYLOAD_ANY, 100000));
+    }
+
+    httpClientConfig.accept(builder);
+
+    return builder.build();
+  }
+
   public static class MattermostClientBuilder {
+
     private Level logLevel;
     private String url;
     private boolean ignoreUnknownProperties;
-    private Consumer<ClientBuilder> httpClientConfig = clientBuilder -> {};
+    private Consumer<ClientBuilder> httpClientConfig = clientBuilder -> {
+    };
 
     public MattermostClientBuilder logLevel(Level logLevel) {
       this.logLevel = logLevel;
@@ -225,23 +244,6 @@ public class MattermostClient implements AutoCloseable, AuditsApi, Authenticatio
     public MattermostClient build() {
       return new MattermostClient(url, logLevel, ignoreUnknownProperties, httpClientConfig);
     }
-  }
-
-  protected Client buildClient(Consumer<ClientBuilder> httpClientConfig) {
-    ClientBuilder builder = ClientBuilder.newBuilder()
-        .register(new MattermostModelMapperProvider(ignoreUnknownProperties))
-        .register(JacksonFeature.class).register(MultiPartFeature.class)
-        // needs for PUT request with null entity
-        // (/commands/{command_id}/regen_token)
-        .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true);
-    if (clientLogLevel != null) {
-      builder.register(new LoggingFeature(Logger.getLogger(getClass().getName()), clientLogLevel,
-          Verbosity.PAYLOAD_ANY, 100000));
-    }
-
-    httpClientConfig.accept(builder);
-
-    return builder.build();
   }
 
   @Override
@@ -283,7 +285,7 @@ public class MattermostClient implements AutoCloseable, AuditsApi, Authenticatio
 
   /**
    * Set Personal Access Token that use to access Mattermost API to this client.
-   * 
+   *
    * @since Mattermost Server 4.1
    */
   public void setAccessToken(String token) {

--- a/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/HttpConfigTest.java
+++ b/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/HttpConfigTest.java
@@ -1,0 +1,53 @@
+package net.bis5.mattermost.client4;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.logging.Level;
+import javax.ws.rs.client.Client;
+import org.glassfish.jersey.client.ClientProperties;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests if {@link net.bis5.mattermost.client4.MattermostClient.MattermostClientBuilder#httpConfig(Consumer)}
+ * is applied.
+ */
+public class HttpConfigTest {
+
+  @Test
+  void testHttpConfig()
+    throws InterruptedException, NoSuchFieldException, IllegalAccessException
+  {
+
+    final int timeout = 1234;
+
+    final MattermostClient client = MattermostClient.builder()
+      .url("http://localhost:815")
+      .logLevel(Level.INFO)
+      .httpConfig(clientBuilder ->
+      {
+        clientBuilder.connectTimeout(timeout, TimeUnit.MILLISECONDS);
+        clientBuilder.readTimeout(timeout, TimeUnit.MILLISECONDS);
+      })
+      .build();
+
+    final Field httpClientField = MattermostClient.class.getDeclaredField("httpClient");
+    httpClientField.setAccessible(true);
+
+    final Client rsClient = (Client) httpClientField.get(client);
+
+    assertThat(
+      "Internally used httpClient uses configured read timeouts",
+      rsClient.getConfiguration().getProperty(ClientProperties.READ_TIMEOUT),
+      is(timeout)
+    );
+
+    assertThat(
+      "Internally used httpClient uses configured connect timeouts",
+      rsClient.getConfiguration().getProperty(ClientProperties.CONNECT_TIMEOUT),
+      is(timeout)
+    );
+  }
+}

--- a/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/HttpConfigTest.java
+++ b/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/HttpConfigTest.java
@@ -1,4 +1,20 @@
+/*
+ * Copyright (c) 2017-present, Takayuki Maruyama
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package net.bis5.mattermost.client4;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.TimeUnit;
@@ -6,8 +22,6 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import javax.ws.rs.client.Client;
 import org.glassfish.jersey.client.ClientProperties;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -18,20 +32,19 @@ public class HttpConfigTest {
 
   @Test
   void testHttpConfig()
-    throws InterruptedException, NoSuchFieldException, IllegalAccessException
-  {
+      throws InterruptedException, NoSuchFieldException, IllegalAccessException {
 
     final int timeout = 1234;
 
     final MattermostClient client = MattermostClient.builder()
-      .url("http://localhost:815")
-      .logLevel(Level.INFO)
-      .httpConfig(clientBuilder ->
-      {
-        clientBuilder.connectTimeout(timeout, TimeUnit.MILLISECONDS);
-        clientBuilder.readTimeout(timeout, TimeUnit.MILLISECONDS);
-      })
-      .build();
+        .url("http://localhost:815")
+        .logLevel(Level.INFO)
+        .httpConfig(clientBuilder ->
+        {
+          clientBuilder.connectTimeout(timeout, TimeUnit.MILLISECONDS);
+          clientBuilder.readTimeout(timeout, TimeUnit.MILLISECONDS);
+        })
+        .build();
 
     final Field httpClientField = MattermostClient.class.getDeclaredField("httpClient");
     httpClientField.setAccessible(true);
@@ -39,15 +52,15 @@ public class HttpConfigTest {
     final Client rsClient = (Client) httpClientField.get(client);
 
     assertThat(
-      "Internally used httpClient uses configured read timeouts",
-      rsClient.getConfiguration().getProperty(ClientProperties.READ_TIMEOUT),
-      is(timeout)
+        "Internally used httpClient uses configured read timeouts",
+        rsClient.getConfiguration().getProperty(ClientProperties.READ_TIMEOUT),
+        is(timeout)
     );
 
     assertThat(
-      "Internally used httpClient uses configured connect timeouts",
-      rsClient.getConfiguration().getProperty(ClientProperties.CONNECT_TIMEOUT),
-      is(timeout)
+        "Internally used httpClient uses configured connect timeouts",
+        rsClient.getConfiguration().getProperty(ClientProperties.CONNECT_TIMEOUT),
+        is(timeout)
     );
   }
 }


### PR DESCRIPTION
Hi @maruTA-bis5,

we have a flaky MM in-house server which sometimes does not answer within 90+ seconds. Because of this I wanted to make to make the RS Client HTTP config accessible to be able tot set the connect and read timeouts. 

If you like it I'd appreciate if you could merge and release this PR so we don't have to keep our fork around for too long. 

Thanks for all the work on the mattermost4j! It helped us in quickly building a chatops interface for one of our applications :)

Cheers,
Paxbit