### PR TITLE
fix: make PostApi#updatePost(String, Post) deprecated

### DIFF
--- a/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/MattermostClient.java
+++ b/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/MattermostClient.java
@@ -1385,8 +1385,8 @@ public class MattermostClient implements AutoCloseable, AuditsApi, Authenticatio
   }
 
   @Override
-  public ApiResponse<Post> updatePost(String postId, Post post) {
-    return doApiPut(getPostRoute(postId), post, Post.class);
+  public ApiResponse<Post> updatePost(Post post) {
+    return doApiPut(getPostRoute(post.getId()), post, Post.class);
   }
 
   @Override

--- a/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/api/PostApi.java
+++ b/mattermost4j-core/src/main/java/net/bis5/mattermost/client4/api/PostApi.java
@@ -44,14 +44,16 @@ public interface PostApi {
   /**
    * updates a post based on the provided post object.
    */
-  default ApiResponse<Post> updatePost(Post post) {
-    return updatePost(post.getId(), post);
-  }
+  ApiResponse<Post> updatePost(Post post);
 
   /**
    * updates a post based on the provided post object.
+   * @deprecated use {@link #updatePost(Post)} instead.
    */
-  ApiResponse<Post> updatePost(String postId, Post post);
+  @Deprecated
+  default ApiResponse<Post> updatePost(String postId, Post post) {
+    return updatePost(post);
+  }
 
   /**
    * partially updates a post. Any missing fields are not updated.

--- a/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/api/PostsApiTest.java
+++ b/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/api/PostsApiTest.java
@@ -160,7 +160,7 @@ class PostsApiTest implements MattermostClientTest {
     Post post = th.createPost(th.basicChannel());
     post.setMessage("UPDATE:" + post.getMessage());
 
-    ApiResponse<Post> response = assertNoError(client.updatePost(post.getId(), post));
+    ApiResponse<Post> response = assertNoError(client.updatePost(post));
     Post updatedPost = response.readEntity();
 
     assertThat(updatedPost.getMessage(), is(post.getMessage()));


### PR DESCRIPTION
closes #189