### PR TITLE
Add missing property totalMsgCountRoot to Channel

### DIFF
--- a/mattermost-models/src/main/java/net/bis5/mattermost/model/Channel.java
+++ b/mattermost-models/src/main/java/net/bis5/mattermost/model/Channel.java
@@ -74,5 +74,8 @@ public class Channel {
   private Map<String, Object> props;
   /* @since Mattermost Server 5.10 */
   private boolean groupConstrained;
+  /* @since Mattermost Server 5.35 */
+  @JsonProperty("total_msg_count_root")
+  private long totalMsgCountRoot;
 
 }


### PR DESCRIPTION
Added with v5.35.0 in mattermost/mattermost-server@ab5925c

resolves #426 