### PR TITLE
Add missing property policyId to Channel

### DIFF
--- a/mattermost-models/src/main/java/net/bis5/mattermost/model/Channel.java
+++ b/mattermost-models/src/main/java/net/bis5/mattermost/model/Channel.java
@@ -74,5 +74,7 @@ public class Channel {
   private Map<String, Object> props;
   /* @since Mattermost Server 5.10 */
   private boolean groupConstrained;
-
+  /* @since Mattermost Server 5.36 */
+  @JsonProperty("policy_id")
+  private String policyId;
 }


### PR DESCRIPTION
Added with v5.36.0 in mattermost/mattermost-server@f36f5c7

resolves #431