### PR TITLE
chore: Set minimum jdk release to 11 

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: failure()
   test-with-server:
+    name: "JDK ${{ matrix.java-version}} - Mattermost ${{ matrix.mattermost-version }}"
     needs: lint
     runs-on: ubuntu-latest
     strategy:
@@ -39,11 +40,14 @@ jobs:
           - 5.37.6
         mattermost-version-latest:
           - 6.3.0
+        java-version:
+          - 11
+          - 17
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
           distribution: temurin
           cache: maven
       - run: docker-compose up -d
@@ -52,7 +56,7 @@ jobs:
       - run: mvn clean verify --show-version
       - name: SonarQube scan
         run: mvn sonar:sonar -s .github/workflows/settings-sonar.xml
-        if: github.repository == 'maruTA-bis5/mattermost4j' && github.actor != 'dependabot[bot]' && matrix.mattermost-version == matrix.mattermost-version-latest
+        if: github.repository == 'maruTA-bis5/mattermost4j' && github.actor != 'dependabot[bot]' && matrix.mattermost-version == matrix.mattermost-version-latest && matrix.java-version == 11
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ mattermost4j
 Mattermost API v4 client for Java.
 
 ## Requirement
-- JDK 8 or 11
-	- for JDK 11 users: You may add these dependencies for runtime
-		- Jakarta XML Binding
-		- Jakarta Activation
+- JDK 11 or later
+	- Additional dependencies required for Java SE runtime environment. These dependencies is not required for Jakarta EE server environment.
+		- Jakarta XML Binding (`jakarta.xml.bind:jakarta.xml.bind-api`)
+		- Jakarta Activation (`jakarta.activation:jakarta.activation-api`)
 - Mattermost Server
     - Please check mattermost4j version compatible with your server instance:
     https://github.com/maruTA-bis5/mattermost4j/wiki#what-version-shoud-i-use
@@ -55,13 +55,13 @@ client.postByIncomingWebhook(payload);
 <dependency>
 	<groupId>net.bis5.mattermost4j</groupId>
 	<artifactId>mattermost4j-core</artifactId>
-	<version>0.25.0</version>
+	<version>${mattermost4j.version}</version>
 </dependency>
 ```
 
 ### Gradle:
 ```
-compile 'net.bis5.mattermost4j:mattermost4j-core:0.25.0'
+compile 'net.bis5.mattermost4j:mattermost4j-core:${mattermost4j.version}'
 ```
 
 ## Contribution

--- a/mattermost-models/pom.xml
+++ b/mattermost-models/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>net.bis5.mattermost4j</groupId>
 		<artifactId>mattermost4j-parent</artifactId>
-		<version>0.25.1-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>mattermost-models</artifactId>
 	<name>Mattermost Data Models</name>

--- a/mattermost-models/pom.xml
+++ b/mattermost-models/pom.xml
@@ -18,8 +18,17 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.moditect</groupId>
-				<artifactId>moditect-maven-plugin</artifactId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.24</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/mattermost-models/src/main/java/module-info.java
+++ b/mattermost-models/src/main/java/module-info.java
@@ -17,8 +17,9 @@
 module net.bis5.mattermost4j.models {
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;
-    requires com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.databind;
     requires java.prefs;
+    requires static lombok;
 
     exports net.bis5.mattermost.model;
     exports net.bis5.mattermost.model.config;
@@ -28,4 +29,13 @@ module net.bis5.mattermost4j.models {
     exports net.bis5.mattermost.model.gitlab;
     exports net.bis5.mattermost.model.license;
     exports net.bis5.mattermost.model.serialize;
+
+    opens net.bis5.mattermost.model to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.config to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.config.consts to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.config.consts.saml to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.config.plugin to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.gitlab to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.license to com.fasterxml.jackson.databind;
+    opens net.bis5.mattermost.model.serialize to com.fasterxml.jackson.databind;
 }

--- a/mattermost-models/src/main/java/net/bis5/mattermost/model/serialize/MattermostPropertyNamingStrategy.java
+++ b/mattermost-models/src/main/java/net/bis5/mattermost/model/serialize/MattermostPropertyNamingStrategy.java
@@ -14,6 +14,7 @@
 
 package net.bis5.mattermost.model.serialize;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.cfg.MapperConfig;
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
@@ -56,11 +57,11 @@ public class MattermostPropertyNamingStrategy extends PropertyNamingStrategy {
   protected PropertyNamingStrategy judgeStrategy(AnnotatedMember member) {
     Class<?> clazz = member.getDeclaringClass();
     if (Config.class.isAssignableFrom(clazz)) {
-      return PropertyNamingStrategy.UPPER_CAMEL_CASE;
+      return PropertyNamingStrategies.UPPER_CAMEL_CASE;
     } else if (clazz.getCanonicalName().startsWith("net.bis5.mattermost.model.config.")) {
-      return PropertyNamingStrategy.UPPER_CAMEL_CASE;
+      return PropertyNamingStrategies.UPPER_CAMEL_CASE;
     } else {
-      return PropertyNamingStrategy.SNAKE_CASE;
+      return PropertyNamingStrategies.SNAKE_CASE;
     }
   }
 }

--- a/mattermost4j-core/pom.xml
+++ b/mattermost4j-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>net.bis5.mattermost4j</groupId>
 		<artifactId>mattermost4j-parent</artifactId>
-		<version>0.25.1-SNAPSHOT</version>
+		<version>1.0.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>mattermost4j-core</artifactId>
 	<name>Mattermost APIv4 Client for Java</name>

--- a/mattermost4j-core/pom.xml
+++ b/mattermost4j-core/pom.xml
@@ -19,6 +19,10 @@
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.module</groupId>
+			<artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
 		</dependency>
@@ -42,7 +46,19 @@
 		<dependency>
 			<groupId>net.bis5.opengraph4j</groupId>
 			<artifactId>opengraph4j</artifactId>
-			<version>0.1.0</version>
+			<version>1.0.1</version>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
+			<version>3.0.0</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.activation</groupId>
+			<artifactId>jakarta.activation-api</artifactId>
+			<version>2.0.0</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.vdurmont</groupId>
@@ -73,7 +89,6 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
 				<configuration>
 					<excludes>
 						<exclude>**/net/bis5/mattermost/client4/api/*.java</exclude>
@@ -82,7 +97,6 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.22.2</version>
 				<configuration>
 					<includes>
 						<include>**/net/bis5/mattermost/client4/api/*.java</include>
@@ -98,8 +112,18 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.moditect</groupId>
-				<artifactId>moditect-maven-plugin</artifactId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<generatedSourcesDirectory>${project.build.directory}/generated-sources/delombok</generatedSourcesDirectory>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.24</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/mattermost4j-core/src/main/java/module-info.java
+++ b/mattermost4j-core/src/main/java/module-info.java
@@ -20,14 +20,18 @@ module net.bis5.mattermost4j.core {
     requires jersey.media.json.jackson;
     requires org.apache.commons.lang3;
 
-    requires transitive com.fasterxml.jackson.annotation;
+    requires com.fasterxml.jackson.annotation;
     requires transitive com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.module.jakarta.xmlbind;
     requires transitive jakarta.ws.rs;
+    requires transitive jakarta.xml.bind;
     requires transitive java.logging;
     requires transitive java.sql;
     requires transitive jersey.media.multipart;
     requires transitive net.bis5.mattermost4j.models;
     requires transitive opengraph4j;
+
+    requires static lombok;
 
     exports net.bis5.mattermost.client4;
     exports net.bis5.mattermost.client4.api;
@@ -35,4 +39,5 @@ module net.bis5.mattermost4j.core {
     exports net.bis5.mattermost.client4.model;
     exports net.bis5.mattermost.jersey.provider;
 
+    opens net.bis5.mattermost.client4.model to com.fasterxml.jackson.databind;
 }

--- a/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/api/TeamsApiTest.java
+++ b/mattermost4j-core/src/test/java/net/bis5/mattermost/client4/api/TeamsApiTest.java
@@ -18,6 +18,7 @@ package net.bis5.mattermost.client4.api;
 
 import static net.bis5.mattermost.client4.Assertions.assertNoError;
 import static net.bis5.mattermost.client4.Assertions.assertStatus;
+import static net.bis5.mattermost.client4.Assertions.isNotSupportVersion;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -184,7 +185,12 @@ class TeamsApiTest implements MattermostClientTest {
   @Test
   void deleteTeam_Permanent_featureDisabled() {
     th.loginSystemAdmin();
+    ApiResponse<Config> configResponse = th.client().getConfig();
+    if (isNotSupportVersion("5.25.4", configResponse)) {
+      return;
+    }
     Config config = th.client().getConfig().readEntity();
+
     assertFalse(config.getServiceSettings().isEnableApiTeamDeletion(), "precondition");
 
     assertStatus(client.deleteTeam(th.basicTeam().getId(), true), Status.UNAUTHORIZED);

--- a/mattermost4j-core/src/test/java/net/bis5/mattermost/jersey/provider/MattermostModelMapperProviderTest.java
+++ b/mattermost4j-core/src/test/java/net/bis5/mattermost/jersey/provider/MattermostModelMapperProviderTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class MattermostModelMapperProviderTest {
 
   @Nested
-  static class IgnoreUnknownPropertiesTest {
+  class IgnoreUnknownPropertiesTest {
     private static final String JSON_INCLUDE_UNKNOWN_PROPERTY = //
         "{\"UNKNOWN_PROPERTY\":\"value\",\"id\":\"qjwhr6gcq3d8d883cgsuk17h9a\"}";
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>net.bis5.mattermost4j</groupId>
 	<artifactId>mattermost4j-parent</artifactId>
-	<version>0.25.1-SNAPSHOT</version>
+	<version>1.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Mattermost4J Parent POM</name>
 	<url>https://github.com/maruTA-bis5/mattermost4j</url>

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
 	</distributionManagement>
 
 	<properties>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sonar.java.spotbugs.reportPaths>${project.build.directory}/spotbugsXml.xml</sonar.java.spotbugs.reportPaths>
 		<sonar.junit.reportPaths>${project.build.directory}/surefire-reports,${project.build.directory}/failsafe-reports</sonar.junit.reportPaths>
@@ -88,8 +88,21 @@
 	<build>
 		<plugins>
 			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.10.1</version>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+							<version>1.18.24</version>
+						</path>
+					</annotationProcessorPaths>
+				</configuration>
+			</plugin>
+			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.2</version>
+				<version>3.0.0-M7</version>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -114,7 +127,7 @@
 					<encoding>UTF-8</encoding>
 					<docencoding>UTF-8</docencoding>
 					<charset>UTF-8</charset>
-					<sourcepath>target/generated-sources/delombok:src/moditect</sourcepath>
+					<sourcepath>target/generated-sources/delombok</sourcepath>
 				</configuration>
 				<executions>
 					<execution>
@@ -170,20 +183,20 @@
 				</executions>
 			</plugin>
 			<plugin>
-				<groupId>org.projectlombok</groupId>
-				<artifactId>lombok-maven-plugin</artifactId>
-				<version>1.18.20.0</version>
+				<groupId>com.github.auties00</groupId>
+				<artifactId>delombok-plugin</artifactId>
+				<version>1.18.24</version>
 				<executions>
 					<execution>
-						<phase>generate-sources</phase>
+						<phase>process-sources</phase>
 						<goals>
 							<goal>delombok</goal>
 						</goals>
 					</execution>
 				</executions>
 				<configuration>
-					<addOutputDirectory>false</addOutputDirectory>
-					<sourceDirectory>src/main/java</sourceDirectory>
+					<rootDirectory>${project.build.sourceDirectory}</rootDirectory>
+					<outputDirectory>${project.build.directory}/generated-sources/delombok</outputDirectory>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -243,27 +256,6 @@
 					<artifactId>jacoco-maven-plugin</artifactId>
 					<version>0.8.7</version>
 				</plugin>
-				<plugin>
-					<groupId>org.moditect</groupId>
-					<artifactId>moditect-maven-plugin</artifactId>
-					<version>1.0.0.RC2</version>
-					<executions>
-						<execution>
-							<id>add-module-info</id>
-							<phase>package</phase>
-							<goals>
-								<goal>add-module-info</goal>
-							</goals>
-							<configuration>
-								<jvmVersion>11</jvmVersion>
-								<overwriteExistingFiles>true</overwriteExistingFiles>
-								<module>
-									<moduleInfoFile>src/moditect/module-info.java</moduleInfoFile>
-								</module>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -296,7 +288,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.24</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -305,6 +297,11 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
+				<version>2.13.3</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.module</groupId>
+				<artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
 				<version>2.13.3</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
BREAKING CHANGE: jdk 8 is no longer supported.

fix #474