### PR TITLE
Unrecognized field: `urgent_mention_count`

### DIFF
--- a/mattermost-models/src/main/java/net/bis5/mattermost/model/ChannelUnread.java
+++ b/mattermost-models/src/main/java/net/bis5/mattermost/model/ChannelUnread.java
@@ -34,6 +34,8 @@ public class ChannelUnread {
   private long msgCount;
   @JsonProperty("mention_count")
   private long mentionCount;
+  @JsonProperty("urgent_mention_count")
+  private long urgentMentionCount;
   private Map<String, String> notifyProps;
   /** @since Mattermost Server 5.35 */
   private long mentionCountRoot;


### PR DESCRIPTION
Sorry, IDK how to add a new field to a model, to maintain backward compatibility.

```
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "urgent_mention_count" (class net.bis5.mattermost.model.ChannelUnread), not marked as ignorable (7 known properties: "msg_count_root", "msg_count", "mention_count_root", "notify_props", "team_id", "channel_id", "mention_count"])
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 162] (through reference chain: net.bis5.mattermost.model.ChannelUnread["urgent_mention_count"])
 ```